### PR TITLE
API-9175 - Fix for scheduler not starting with lazy val 

### DIFF
--- a/app/uk/gov/hmrc/gatekeeperemail/scheduled/RunningOfScheduledJobs.scala
+++ b/app/uk/gov/hmrc/gatekeeperemail/scheduled/RunningOfScheduledJobs.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.gatekeeperemail.scheduled
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
@@ -25,18 +26,19 @@ import org.apache.pekko.actor.{Cancellable, Scheduler}
 import play.api.inject.ApplicationLifecycle
 import play.api.{Application, Logging}
 
-/** All implementing classes must be singletons - see https://www.playframework.com/documentation/2.8.x/ScalaDependencyInjection#Stopping/cleaning-up
-  */
-trait RunningOfScheduledJobs extends Logging {
+@Singleton
+class RunningOfScheduledJobs @Inject() (
+    val application: Application,
+    val applicationLifecycle: ApplicationLifecycle,
+    emailSendingJob: EmailSendingJob
+)(implicit
+    val ec: ExecutionContext
+) extends Logging {
+  val scheduledJobs: Seq[ScheduledJob] = Seq(emailSendingJob)
 
-  implicit val ec: ExecutionContext
-  val application: Application
-  val scheduledJobs: Seq[ScheduledJob]
+  val scheduler: Scheduler = application.actorSystem.scheduler
 
-  lazy val scheduler: Scheduler = application.actorSystem.scheduler
-  lazy val applicationLifecycle: ApplicationLifecycle
-
-  lazy val cancellables: Seq[Cancellable] =
+  val cancellables: Seq[Cancellable] =
     scheduledJobs.map { job =>
       scheduler.scheduleWithFixedDelay(job.initialDelay, job.interval)(new Runnable() {
         override def run(): Unit = {

--- a/app/uk/gov/hmrc/gatekeeperemail/scheduled/ScheduledJobsRunner.scala
+++ b/app/uk/gov/hmrc/gatekeeperemail/scheduled/ScheduledJobsRunner.scala
@@ -26,20 +26,21 @@ import org.apache.pekko.actor.{Cancellable, Scheduler}
 import play.api.inject.ApplicationLifecycle
 import play.api.{Application, Logging}
 
+case class ScheduledJobs(allJobs: List[ScheduledJob])
+
 @Singleton
-class RunningOfScheduledJobs @Inject() (
-    val application: Application,
-    val applicationLifecycle: ApplicationLifecycle,
-    emailSendingJob: EmailSendingJob
+class ScheduledJobsRunner @Inject() (
+    application: Application,
+    applicationLifecycle: ApplicationLifecycle,
+    scheduledJobs: ScheduledJobs
 )(implicit
     val ec: ExecutionContext
 ) extends Logging {
-  val scheduledJobs: Seq[ScheduledJob] = Seq(emailSendingJob)
 
   val scheduler: Scheduler = application.actorSystem.scheduler
 
   val cancellables: Seq[Cancellable] =
-    scheduledJobs.map { job =>
+    scheduledJobs.allJobs.map { job =>
       scheduler.scheduleWithFixedDelay(job.initialDelay, job.interval)(new Runnable() {
         override def run(): Unit = {
           val stopWatch = new StopWatch

--- a/app/uk/gov/hmrc/gatekeeperemail/scheduled/SchedulerModule.scala
+++ b/app/uk/gov/hmrc/gatekeeperemail/scheduled/SchedulerModule.scala
@@ -16,11 +16,25 @@
 
 package uk.gov.hmrc.gatekeeperemail.scheduled
 
-import com.google.inject.AbstractModule
+import javax.inject.{Inject, Singleton}
 
-class SchedulerModule extends AbstractModule {
+import com.google.inject.Provider
 
-  override def configure(): Unit = {
-    bind(classOf[RunningOfScheduledJobs]).asEagerSingleton()
-  }
+import play.api.inject.Module
+import play.api.{Configuration, Environment}
+
+class SchedulerModule extends Module {
+
+  override def bindings(environment: Environment, configuration: Configuration) = Seq(
+    bind[ScheduledJobs].toProvider[ScheduledJobsProvider],
+    bind[ScheduledJobsRunner].toSelf.eagerly()
+  )
+}
+
+@Singleton
+class ScheduledJobsProvider @Inject() (
+    emailSendingJob: EmailSendingJob
+) extends Provider[ScheduledJobs] {
+
+  override def get(): ScheduledJobs = ScheduledJobs(List(emailSendingJob))
 }

--- a/app/uk/gov/hmrc/gatekeeperemail/scheduled/SchedulerModule.scala
+++ b/app/uk/gov/hmrc/gatekeeperemail/scheduled/SchedulerModule.scala
@@ -16,29 +16,11 @@
 
 package uk.gov.hmrc.gatekeeperemail.scheduled
 
-import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext
-
 import com.google.inject.AbstractModule
-
-import play.api.Application
-import play.api.inject.ApplicationLifecycle
 
 class SchedulerModule extends AbstractModule {
 
   override def configure(): Unit = {
-    bind(classOf[Scheduler]).asEagerSingleton()
+    bind(classOf[RunningOfScheduledJobs]).asEagerSingleton()
   }
-}
-
-@Singleton
-class Scheduler @Inject() (
-    val lifecycle: ApplicationLifecycle,
-    override val application: Application,
-    emailSendingJob: EmailSendingJob
-)(
-    override implicit val ec: ExecutionContext
-) extends RunningOfScheduledJobs {
-  override val scheduledJobs: Seq[ScheduledJob] = Seq(emailSendingJob)
-  override lazy val applicationLifecycle        = lifecycle
 }

--- a/app/uk/gov/hmrc/gatekeeperemail/scheduled/SchedulerModule.scala
+++ b/app/uk/gov/hmrc/gatekeeperemail/scheduled/SchedulerModule.scala
@@ -35,6 +35,5 @@ class SchedulerModule extends Module {
 class ScheduledJobsProvider @Inject() (
     emailSendingJob: EmailSendingJob
 ) extends Provider[ScheduledJobs] {
-
   override def get(): ScheduledJobs = ScheduledJobs(List(emailSendingJob))
 }

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -33,5 +33,6 @@
 
     <root level="INFO">
         <appender-ref ref="FILE"/>
+        <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/test/uk/gov/hmrc/gatekeeperemail/scheduled/RunningOfSchedulesJobsSpec.scala
+++ b/test/uk/gov/hmrc/gatekeeperemail/scheduled/RunningOfSchedulesJobsSpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.gatekeeperemail.scheduled
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.{Deadline, DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -91,14 +92,10 @@ class RunningOfSchedulesJobsSpec extends HmrcSpec with ScalaFutures with GuiceOn
 
   "When stopping the app, the scheduled job runner" should {
     "cancel all of the scheduled jobs" in new TestCase {
-      private val testApp = fakeApplication()
-      private val runner  = new RunningOfScheduledJobs {
-        override val ec: ExecutionContext                            = ExecutionContext.Implicits.global
-        override lazy val applicationLifecycle: ApplicationLifecycle = testApp.injector.instanceOf[ApplicationLifecycle]
-        override val scheduledJobs: Seq[LockedScheduledJob]          = Seq.empty
-        override val application: Application                        = testApp
-        override lazy val cancellables                               = Seq(new StubCancellable, new StubCancellable)
-      }
+      private val testApp              = fakeApplication()
+      private val applicationLifecycle = testApp.injector.instanceOf[ApplicationLifecycle]
+      private val emailSendingJob      = testApp.injector.instanceOf[EmailSendingJob]
+      private val runner               = RunningOfScheduledJobs(testApp, applicationLifecycle, emailSendingJob)
 
       every(runner.cancellables) should not be Symbol("cancelled")
       await(testApp.stop())

--- a/test/uk/gov/hmrc/gatekeeperemail/scheduled/ScheduledJobsRunnerSpec.scala
+++ b/test/uk/gov/hmrc/gatekeeperemail/scheduled/ScheduledJobsRunnerSpec.scala
@@ -77,7 +77,7 @@ trait TestCase {
   }
 }
 
-class RunningOfSchedulesJobsSpec extends HmrcSpec with ScalaFutures with GuiceOneAppPerTest with BeforeAndAfterEach {
+class ScheduledJobsRunnerSpec extends HmrcSpec with ScalaFutures with GuiceOneAppPerTest with BeforeAndAfterEach {
 
   override def fakeApplication() =
     new GuiceApplicationBuilder()
@@ -95,7 +95,7 @@ class RunningOfSchedulesJobsSpec extends HmrcSpec with ScalaFutures with GuiceOn
       private val testApp              = fakeApplication()
       private val applicationLifecycle = testApp.injector.instanceOf[ApplicationLifecycle]
       private val emailSendingJob      = testApp.injector.instanceOf[EmailSendingJob]
-      private val runner               = RunningOfScheduledJobs(testApp, applicationLifecycle, emailSendingJob)
+      private val runner               = ScheduledJobsRunner(testApp, applicationLifecycle, ScheduledJobs(List(emailSendingJob)))
 
       every(runner.cancellables) should not be Symbol("cancelled")
       await(testApp.stop())

--- a/test/uk/gov/hmrc/gatekeeperemail/scheduled/ScheduledJobsRunnerSpec.scala
+++ b/test/uk/gov/hmrc/gatekeeperemail/scheduled/ScheduledJobsRunnerSpec.scala
@@ -17,10 +17,8 @@
 package uk.gov.hmrc.gatekeeperemail.scheduled
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.{Deadline, DurationInt, FiniteDuration}
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext}
 
-import org.apache.pekko.actor.{Cancellable, Scheduler}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.concurrent.ScalaFutures
@@ -32,50 +30,10 @@ import play.api.inject.ApplicationLifecycle
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.apiplatform.modules.common.utils.HmrcSpec
-
-trait TestCase {
-
-  class StubbedScheduler extends Scheduler {
-
-    override def scheduleWithFixedDelay(
-        initialDelay: FiniteDuration,
-        delay: FiniteDuration
-    )(
-        runnable: Runnable
-    )(implicit executor: ExecutionContext): Cancellable = new Cancellable {
-      override def cancel(): Boolean    = true
-      override def isCancelled: Boolean = false
-    }
-    def maxFrequency: Double = 1
-
-    def scheduleOnce(delay: FiniteDuration, runnable: Runnable)(implicit executor: ExecutionContext): Cancellable = new Cancellable {
-      override def cancel(): Boolean    = true
-      override def isCancelled: Boolean = false
-    }
-
-    override def schedule(initialDelay: FiniteDuration, interval: FiniteDuration, runnable: Runnable)(implicit executor: ExecutionContext) = ???
-  }
-
-  class TestScheduledJob extends ScheduledJob {
-    override lazy val initialDelay: FiniteDuration = 2.seconds
-    override lazy val interval: FiniteDuration     = 3.seconds
-    def name: String                               = "TestScheduledJob"
-    def isExecuted: Boolean                        = true
-
-    override def execute(implicit ec: ExecutionContext): Future[Result] = Future.successful(Result("done"))
-    var isRunning: Future[Boolean]                                      = Future.successful(false)
-  }
-  val testScheduledJob = new TestScheduledJob
-
-  class StubCancellable extends Cancellable {
-    var isCancelled = false
-
-    def cancel(): Boolean = {
-      isCancelled = true
-      isCancelled
-    }
-  }
-}
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import scala.concurrent.Promise
+import scala.util.Success
 
 class ScheduledJobsRunnerSpec extends HmrcSpec with ScalaFutures with GuiceOneAppPerTest with BeforeAndAfterEach {
 
@@ -88,38 +46,61 @@ class ScheduledJobsRunnerSpec extends HmrcSpec with ScalaFutures with GuiceOneAp
       .disable[SchedulerModule]
       .build()
 
-  trait Setup extends TestCase {}
+  "ScheduledJobsRunner" should {
+    "Invoke execute method on jobs after small delay" in {
+      val cdl = new CountDownLatch(2)
+      val testScheduledJob1     = new TestScheduledJob(cdl)
+      val testScheduledJob2     = new TestScheduledJob(cdl)
 
-  "When stopping the app, the scheduled job runner" should {
-    "cancel all of the scheduled jobs" in new TestCase {
-      private val testApp              = fakeApplication()
-      private val applicationLifecycle = testApp.injector.instanceOf[ApplicationLifecycle]
-      private val emailSendingJob      = testApp.injector.instanceOf[EmailSendingJob]
-      private val runner               = ScheduledJobsRunner(testApp, applicationLifecycle, ScheduledJobs(List(emailSendingJob)))
+      val testApp              = fakeApplication()
+      val applicationLifecycle = testApp.injector.instanceOf[ApplicationLifecycle]
+
+      ScheduledJobsRunner(testApp, applicationLifecycle, ScheduledJobs(List(testScheduledJob1, testScheduledJob2)))
+
+      // Both jobs should be executed quickly
+      cdl.await(5, TimeUnit.SECONDS) shouldBe true
+
+      await(testApp.stop())
+    }
+  
+    "When stopping the app, the scheduled job runner should cancel all of the scheduled jobs" in {
+      val cdl = new CountDownLatch(2)
+      val testScheduledJob1     = new TestScheduledJob(cdl)
+      val testScheduledJob2     = new TestScheduledJob(cdl)
+
+      val testApp              = fakeApplication()
+      val applicationLifecycle = testApp.injector.instanceOf[ApplicationLifecycle]
+
+      val runner               = ScheduledJobsRunner(testApp, applicationLifecycle, ScheduledJobs(List(testScheduledJob1, testScheduledJob2)))
 
       every(runner.cancellables) should not be Symbol("cancelled")
       await(testApp.stop())
       every(runner.cancellables) shouldBe Symbol("cancelled")
     }
 
-    "block while scheduled jobs are still running" in new TestCase {
-      private val testApp = fakeApplication()
-      val stoppableJob    = new TestScheduledJob() {
-        override def name: String = "StoppableJob"
-      }
+    "block while scheduled jobs are still running" in {
+      val testApp              = fakeApplication()
+      val applicationLifecycle = testApp.injector.instanceOf[ApplicationLifecycle]
 
-      stoppableJob.isRunning = Future.successful(true)
+      val startedMarker = new CountDownLatch(1)
+      val jobCompleter = Promise[String]
+      val job = new ShutdownDelayedScheduledJob(startedMarker, jobCompleter)
 
-      val deadline: Deadline = 5000.milliseconds.fromNow
-      while (deadline.hasTimeLeft()) {
-        /* Intentionally burning CPU cycles for fixed period */
-      }
+      val runner               = ScheduledJobsRunner(testApp, applicationLifecycle, ScheduledJobs(List(job)))
+
+      // Ensure we are running execute block
+      startedMarker.await(5, TimeUnit.SECONDS) shouldBe true
 
       val stopFuture = testApp.stop()
+      // When we stop the app it should wait for the runnning job to complete
       stopFuture should not be Symbol("completed")
 
-      stoppableJob.isRunning = Future.successful(false)
+      // Complete the job
+      jobCompleter.complete(Success("Done"))
+
+      // Check everything is shutdown
       eventually(timeout(Span(1, Minute))) { stopFuture shouldBe Symbol("completed") }
+      every(runner.cancellables) shouldBe Symbol("cancelled")
     }
   }
 }

--- a/test/uk/gov/hmrc/gatekeeperemail/scheduled/ScheduledJobsRunnerSpec.scala
+++ b/test/uk/gov/hmrc/gatekeeperemail/scheduled/ScheduledJobsRunnerSpec.scala
@@ -17,7 +17,9 @@
 package uk.gov.hmrc.gatekeeperemail.scheduled
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{ExecutionContext}
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ExecutionContext, Promise}
+import scala.util.Success
 
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.Eventually.eventually
@@ -30,10 +32,6 @@ import play.api.inject.ApplicationLifecycle
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.apiplatform.modules.common.utils.HmrcSpec
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import scala.concurrent.Promise
-import scala.util.Success
 
 class ScheduledJobsRunnerSpec extends HmrcSpec with ScalaFutures with GuiceOneAppPerTest with BeforeAndAfterEach {
 
@@ -47,55 +45,89 @@ class ScheduledJobsRunnerSpec extends HmrcSpec with ScalaFutures with GuiceOneAp
       .build()
 
   "ScheduledJobsRunner" should {
-    "Invoke execute method on jobs after small delay" in {
-      val cdl = new CountDownLatch(2)
-      val testScheduledJob1     = new TestScheduledJob(cdl)
-      val testScheduledJob2     = new TestScheduledJob(cdl)
-
+    "not execute jobs during the initial delay" in {
       val testApp              = fakeApplication()
       val applicationLifecycle = testApp.injector.instanceOf[ApplicationLifecycle]
+      val testJob              = new SequencingScheduledJob(5.seconds)
 
-      ScheduledJobsRunner(testApp, applicationLifecycle, ScheduledJobs(List(testScheduledJob1, testScheduledJob2)))
+      ScheduledJobsRunner(testApp, applicationLifecycle, ScheduledJobs(List(testJob)))
 
-      // Both jobs should be executed quickly
-      cdl.await(5, TimeUnit.SECONDS) shouldBe true
+      // it won't start yet - see CDL await
+      withClue("testJob has started too soon") { testJob.awaitStarted(4.seconds) shouldBe false }
+
+      // it should have started now
+      withClue("testJob has not started") { testJob.awaitStarted(5.seconds) shouldBe true }
 
       await(testApp.stop())
     }
-  
-    "When stopping the app, the scheduled job runner should cancel all of the scheduled jobs" in {
-      val cdl = new CountDownLatch(2)
-      val testScheduledJob1     = new TestScheduledJob(cdl)
-      val testScheduledJob2     = new TestScheduledJob(cdl)
 
+    "execute jobs after the initial delay" in {
       val testApp              = fakeApplication()
       val applicationLifecycle = testApp.injector.instanceOf[ApplicationLifecycle]
 
-      val runner               = ScheduledJobsRunner(testApp, applicationLifecycle, ScheduledJobs(List(testScheduledJob1, testScheduledJob2)))
+      val testJob1 = new SequencingScheduledJob(1.seconds)
+      val testJob2 = new SequencingScheduledJob(1.seconds)
+
+      ScheduledJobsRunner(testApp, applicationLifecycle, ScheduledJobs(List(testJob1, testJob2)))
+
+      // Both jobs should be executed quickly
+      withClue("testJob1 has not started") { testJob1.awaitStarted(5.seconds) shouldBe true }
+      withClue("testJob2 has not started") { testJob2.awaitStarted(5.seconds) shouldBe true }
+
+      await(testApp.stop())
+    }
+
+    "cancel all of the scheduled jobs when stopping the app" in {
+      val testApp              = fakeApplication()
+      val applicationLifecycle = testApp.injector.instanceOf[ApplicationLifecycle]
+
+      val testJob1 = new SequencingScheduledJob()
+      val testJob2 = new SequencingScheduledJob()
+
+      val runner = ScheduledJobsRunner(testApp, applicationLifecycle, ScheduledJobs(List(testJob1, testJob2)))
 
       every(runner.cancellables) should not be Symbol("cancelled")
-      await(testApp.stop())
+
+      val stopFuture = testApp.stop()
+      eventually(timeout(Span(1, Minute))) { stopFuture shouldBe Symbol("completed") }
+
       every(runner.cancellables) shouldBe Symbol("cancelled")
     }
 
-    "block while scheduled jobs are still running" in {
+    "demonstrate job completion can be delayed in SequencingScheduledJob before next test" in {
       val testApp              = fakeApplication()
       val applicationLifecycle = testApp.injector.instanceOf[ApplicationLifecycle]
 
-      val startedMarker = new CountDownLatch(1)
       val jobCompleter = Promise[String]
-      val job = new ShutdownDelayedScheduledJob(startedMarker, jobCompleter)
+      val testJob      = new SequencingScheduledJob(1.seconds, jobCompleter)
 
-      val runner               = ScheduledJobsRunner(testApp, applicationLifecycle, ScheduledJobs(List(job)))
+      ScheduledJobsRunner(testApp, applicationLifecycle, ScheduledJobs(List(testJob)))
+
+      withClue("testJob has started too soon") { testJob.awaitCompleted(5.seconds) shouldBe false }
+      jobCompleter.complete(Success("Done"))
+      withClue("testJob has not started") { testJob.awaitCompleted(1.seconds) shouldBe true }
+
+      await(testApp.stop())
+    }
+
+    "block shutdown while scheduled jobs are still running" in {
+      val testApp              = fakeApplication()
+      val applicationLifecycle = testApp.injector.instanceOf[ApplicationLifecycle]
+
+      val jobCompleter = Promise[String]
+      val testJob      = new SequencingScheduledJob(1.seconds, jobCompleter)
+
+      val runner = ScheduledJobsRunner(testApp, applicationLifecycle, ScheduledJobs(List(testJob)))
 
       // Ensure we are running execute block
-      startedMarker.await(5, TimeUnit.SECONDS) shouldBe true
+      withClue("testJob has not started") { testJob.awaitStarted(5.seconds) shouldBe true }
 
       val stopFuture = testApp.stop()
+
       // When we stop the app it should wait for the runnning job to complete
       stopFuture should not be Symbol("completed")
 
-      // Complete the job
+      // Complete the running scheduled job
       jobCompleter.complete(Success("Done"))
 
       // Check everything is shutdown

--- a/test/uk/gov/hmrc/gatekeeperemail/scheduled/TestScheduledJob.scala
+++ b/test/uk/gov/hmrc/gatekeeperemail/scheduled/TestScheduledJob.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gatekeeperemail.scheduled
+
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.{ExecutionContext, Future}
+import java.util.concurrent.CountDownLatch
+import scala.concurrent.Promise
+
+class TestScheduledJob(startedMarker: CountDownLatch) extends ScheduledJob {
+  override lazy val initialDelay: FiniteDuration = 1.seconds
+  override lazy val interval: FiniteDuration     = 5.seconds
+  def name: String                               = "TestScheduledJob"
+
+  override def execute(implicit ec: ExecutionContext): Future[Result] = {
+    startedMarker.countDown()
+    Future.successful(Result("done"))
+  }
+
+  var isRunning: Future[Boolean] = Future.successful(false)
+}
+
+class ShutdownDelayedScheduledJob(startedMarker: CountDownLatch, promise: Promise[String]) extends ScheduledJob {
+  override lazy val initialDelay: FiniteDuration = 1.seconds
+  override lazy val interval: FiniteDuration     = 30.seconds
+  def name: String                               = "StopDelayedScheduledJob"
+
+  override def execute(implicit ec: ExecutionContext): Future[Result] = {
+    startedMarker.countDown()
+    promise.future.map(Result(_))
+  }
+}

--- a/test/uk/gov/hmrc/gatekeeperemail/scheduled/TestScheduledJob.scala
+++ b/test/uk/gov/hmrc/gatekeeperemail/scheduled/TestScheduledJob.scala
@@ -16,31 +16,33 @@
 
 package uk.gov.hmrc.gatekeeperemail.scheduled
 
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
-import scala.concurrent.{ExecutionContext, Future}
 import java.util.concurrent.CountDownLatch
-import scala.concurrent.Promise
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 
-class TestScheduledJob(startedMarker: CountDownLatch) extends ScheduledJob {
-  override lazy val initialDelay: FiniteDuration = 1.seconds
-  override lazy val interval: FiniteDuration     = 5.seconds
-  def name: String                               = "TestScheduledJob"
+class SequencingScheduledJob(
+    val initialDelay: FiniteDuration = 1.seconds,
+    jobCompleter: Promise[String] = Promise.successful("Done")
+) extends ScheduledJob {
+  override lazy val interval: FiniteDuration = 1.hour
+  def name: String                           = "SequencingScheduledJob1"
 
-  override def execute(implicit ec: ExecutionContext): Future[Result] = {
-    startedMarker.countDown()
-    Future.successful(Result("done"))
+  private val startedMarker   = CountDownLatch(1)
+  private val completedMarker = CountDownLatch(1)
+
+  def awaitStarted(timeout: FiniteDuration): Boolean   = {
+    startedMarker.await(timeout.length, timeout.unit)
+  }
+  def awaitCompleted(timeout: FiniteDuration): Boolean = {
+    completedMarker.await(timeout.length, timeout.unit)
   }
 
-  var isRunning: Future[Boolean] = Future.successful(false)
-}
-
-class ShutdownDelayedScheduledJob(startedMarker: CountDownLatch, promise: Promise[String]) extends ScheduledJob {
-  override lazy val initialDelay: FiniteDuration = 1.seconds
-  override lazy val interval: FiniteDuration     = 30.seconds
-  def name: String                               = "StopDelayedScheduledJob"
-
   override def execute(implicit ec: ExecutionContext): Future[Result] = {
     startedMarker.countDown()
-    promise.future.map(Result(_))
+    val future = jobCompleter.future.map(Result(_))
+    future.onComplete { case _ =>
+      completedMarker.countDown()
+    }
+    future
   }
 }


### PR DESCRIPTION
Lazy val was a fix for Scala 3 initialisation order but broken runtime.
Rework the whole of scheduler